### PR TITLE
Add a default question when opening the page for the first time

### DIFF
--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -460,10 +460,10 @@ const Home: NextPage = () => {
             <main>
                 <Header page="index" />
 
-                <p><b>
+                <p>
                   Since this is still an early test, all questions and answers are stored.<br/>
                   Zero other information is collected.
-                </b></p>
+                </p>
 
                 <ul>
                     {entries.map((entry, i) => {

--- a/web/src/searchbox.tsx
+++ b/web/src/searchbox.tsx
@@ -16,7 +16,7 @@ export const SearchBox: React.FC<{search: (
     ) => void,
 }> = ({search}) => {
 
-    const [ query, setQuery ] = useState("");
+    const [ query, setQuery ] = useState("What is an AI arms race?");
     const [ loading, setLoading ] = useState(false);
     const [ followups, setFollowups ] = useState<Followup[]>([]);
 
@@ -39,6 +39,14 @@ export const SearchBox: React.FC<{search: (
         // set focus on the input box
         if (!loading) inputRef.current?.focus();
     }, [loading]);
+
+    // on first mount focus and set cursor to end of input
+    useEffect(() => { 
+        if (!inputRef.current) return;
+        inputRef.current.focus();
+        inputRef.current.selectionStart = inputRef.current.textLength;
+        inputRef.current.selectionEnd = inputRef.current.textLength;
+    }, []);
 
     if (loading) return <></>;
     return (<>


### PR DESCRIPTION
@ccstan99 @henri123lemoine @Thomas-Lemoine and anyone else with an option, I want some feedback on this. 

It seems from looking at interactions that people freeze when asked for a random question, or ask something like "what's this?" - not very helpful with the current chatbot model. This could launch them down the right path more often.