### PR TITLE
link to duckduckgo when url field empty

### DIFF
--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -72,9 +72,14 @@ const ShowCitation: React.FC<{citation: Citation, i: number}> = ({citation, i}) 
     if (citation.date && citation.date !== "")
         c_str += " - " + citation.date;
 
+    // if we don't have a url, link to a duckduckgo search for the title instead
+    const url = citation.url && citation.url !== ""
+                ? citation.url 
+                : `https://duckduckgo.com/?q=${encodeURIComponent(citation.title)}`;
+
     return (
         <A className={Colours[i % Colours.length] + " border-2 flex items-center rounded my-2 text-sm no-underline w-fit"}
-            href={citation.url}>
+            href={url}>
             <span className="mx-1"> [{i + 1}] </span>
             <p className="mx-1 my-0"> {c_str} </p>
         </A>


### PR DESCRIPTION
In theory we shouldn't have any sources without a URL once the new dataset in plugged in, but this should be a good stopgap, and a last line of defence in case anything slips past.