### PR TITLE
Test new ARD embeddings

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,5 @@
 OPENAI_API_KEY="sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 PINECONE_API_KEY="" # leave blank to use our online API instead
-PINECONE_INDEX="stampy-chat-ard"
+PINECONE_INDEX_NAME="stampy-chat-ard"
 PINECONE_ENV="us-central1-gcp"
 LOGGING_URL="" # leave blank if you're not testing logging specifically

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,3 +1,5 @@
 OPENAI_API_KEY="sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 PINECONE_API_KEY="" # leave blank to use our online API instead
+PINECONE_INDEX="stampy-chat-ard"
+PINECONE_ENV="us-central1-gcp"
 LOGGING_URL="" # leave blank if you're not testing logging specifically

--- a/api/env.py
+++ b/api/env.py
@@ -12,6 +12,8 @@ else:
 
 OPENAI_API_KEY   = os.environ.get('OPENAI_API_KEY')
 PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY')
+PINECONE_INDEX   = os.environ.get('PINECONE_INDEX_NAME')
+PINECONE_ENV     = os.environ.get('PINECONE_ENVIRONMENT')
 LOGGING_URL      = os.environ.get('LOGGING_URL')
 PINECONE_INDEX   = None
 
@@ -22,10 +24,10 @@ if PINECONE_API_KEY is not None and PINECONE_API_KEY != "":
 
     pinecone.init(
         api_key = PINECONE_API_KEY,
-        environment = "us-east1-gcp",
+        environment = PINECONE_ENV,
     )
 
-    PINECONE_INDEX = pinecone.Index(index_name="alignment-search")
+    PINECONE_INDEX = pinecone.Index(index_name=PINECONE_INDEX)
 
 # log something only if the logging url is set
 def log(*args, end="\n"):

--- a/api/env.py
+++ b/api/env.py
@@ -12,7 +12,7 @@ else:
 
 OPENAI_API_KEY   = os.environ.get('OPENAI_API_KEY')
 PINECONE_API_KEY = os.environ.get('PINECONE_API_KEY')
-PINECONE_INDEX   = os.environ.get('PINECONE_INDEX_NAME')
+PINECONE_INDEX_NAME = os.environ.get('PINECONE_INDEX_NAME')
 PINECONE_ENV     = os.environ.get('PINECONE_ENVIRONMENT')
 LOGGING_URL      = os.environ.get('LOGGING_URL')
 PINECONE_INDEX   = None
@@ -27,7 +27,7 @@ if PINECONE_API_KEY is not None and PINECONE_API_KEY != "":
         environment = PINECONE_ENV,
     )
 
-    PINECONE_INDEX = pinecone.Index(index_name=PINECONE_INDEX)
+    PINECONE_INDEX = pinecone.Index(index_name=PINECONE_INDEX_NAME)
 
 # log something only if the logging url is set
 def log(*args, end="\n"):

--- a/api/get_blocks.py
+++ b/api/get_blocks.py
@@ -60,7 +60,7 @@ def get_top_k_blocks(index, user_query: str, k: int) -> List[Block]:
 
         print('Pinecone index not found, performing semantic search on chat.stampy.ai endpoint.')
         response = requests.post(
-            "https://chat.stampy.ai/semantic",
+            "https://chat.stampy.ai:8443/semantic",
             json = {
                 "query": user_query,
                 "k": k

--- a/api/get_blocks.py
+++ b/api/get_blocks.py
@@ -58,9 +58,9 @@ def get_top_k_blocks(index, user_query: str, k: int) -> List[Block]:
 
     if index is None:
 
-        print('Pinecone index not found, performing semantic search on alignmentsearch-api.up.railway.app endpoint.')
+        print('Pinecone index not found, performing semantic search on chat.stampy.ai endpoint.')
         response = requests.post(
-            "https://alignmentsearch-api.up.railway.app/semantic",
+            "https://chat.stampy.ai/semantic",
             json = {
                 "query": user_query,
                 "k": k
@@ -79,7 +79,7 @@ def get_top_k_blocks(index, user_query: str, k: int) -> List[Block]:
     print(f'Time to get embedding: {t1-t:.2f}s')
 
     query_response = index.query(
-        namespace="alignment-search",  # ugly, sorry
+        namespace="",  # ugly, sorry
         top_k=k,
         include_values=False,
         include_metadata=True,

--- a/api/get_blocks.py
+++ b/api/get_blocks.py
@@ -79,7 +79,7 @@ def get_top_k_blocks(index, user_query: str, k: int) -> List[Block]:
     print(f'Time to get embedding: {t1-t:.2f}s')
 
     query_response = index.query(
-        namespace="",  # ugly, sorry
+        namespace='regular',
         top_k=k,
         include_values=False,
         include_metadata=True,
@@ -94,10 +94,9 @@ def get_top_k_blocks(index, user_query: str, k: int) -> List[Block]:
 
         blocks.append(Block(
             title = match['metadata']['title'],
-            author = match['metadata']['author'],
+            author = match['metadata']['authors'],
             date = date,
             url = match['metadata']['url'],
-            tags = match['metadata']['tags'],
             text = strip_block(match['metadata']['text'])
         ))
 


### PR DESCRIPTION
I was testing the prompteng workflow, which was working nicely with the default setup, but ran into 2 problems depending trying to change the pinecone used. Looks like `get_blocks.py` returns something leading to `KeyError: 'citations'`

1. ~~When switching out the default pinecone from railway to chat.stampy.ai:~~
Added port:8443 worked!

2. When updating the pinecone key, env, and index to the new values with ARD embeddings:
~~`replace() argument 2 must be str, not None`~~
Looks like there's some issues with the metadata format in pinecone. I'll wait until that's been resolved.