### PR TITLE
Add Budget Manager + Support for Anthropic, Cohere, Palm (100+ LLMs using LiteLLM)

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -15,6 +15,7 @@ werkzeug = "==2.0.3"
 flask-cors = "*"
 # ---- </flask stuff> ----
 openai = "==0.27.2"
+litellm = "==0.1.619"
 numpy = "==1.24.2"
 tenacity = "==8.2.2"
 tiktoken = "*"

--- a/api/src/stampy_chat/chat.py
+++ b/api/src/stampy_chat/chat.py
@@ -2,6 +2,8 @@
 from dataclasses import asdict
 from typing import List, Dict, Callable
 import openai
+import litellm
+import uuid
 import re
 import tiktoken
 import time
@@ -25,6 +27,9 @@ HISTORY_FRACTION = 0.25 # the (approximate) fraction of num_tokens to use for hi
 CONTEXT_FRACTION = 0.5  # the (approximate) fraction of num_tokens to use for context text before truncating
 
 ENCODER = tiktoken.get_encoding("cl100k_base")
+
+# initialize a budget manager to control costs for gpt-4/other llms
+budget_manager = litellm.BudgetManager(project_name="stamp_chat")
 
 DEBUG_PRINT = True
 
@@ -142,7 +147,7 @@ def construct_prompt(query: str, mode: str, history: List[Dict[str, str]], conte
 import time
 import json
 
-def talk_to_robot_internal(index, query: str, mode: str, history: List[Dict[str, str]], k: int = STANDARD_K, log: Callable = print):
+def talk_to_robot_internal(index, query: str, mode: str, history: List[Dict[str, str]], k: int = STANDARD_K, log: Callable = print, session_id: str = ""):
     try:
         # 1. Find the most relevant blocks from the Alignment Research Dataset
         yield {"state": "loading", "phase": "semantic"}
@@ -181,7 +186,11 @@ def talk_to_robot_internal(index, query: str, mode: str, history: List[Dict[str,
         t1 = time.time()
         response = ''
 
-        for chunk in openai.ChatCompletion.create(
+        # check if budget exceeded for session
+        if budget_manager.get_current_cost(user=session_id) <= budget_manager.get_total_budget(session_id):
+            raise Exception(f"Exceeded the maximum budget for this session")
+
+        for chunk in litellm.completion(
             model=COMPLETIONS_MODEL,
             messages=prompt,
             max_tokens=max_tokens_completion,
@@ -189,6 +198,7 @@ def talk_to_robot_internal(index, query: str, mode: str, history: List[Dict[str,
             temperature=0, # may or may not be a good idea
         ):
             res = chunk["choices"][0]["delta"]
+            budget_manager.update_cost(completion_obj=response, user=session_id)
             if res is not None and res.get("content") is not None:
                 response += res["content"]
                 yield {"state": "streaming", "content": res["content"]}
@@ -225,13 +235,16 @@ def talk_to_robot_internal(index, query: str, mode: str, history: List[Dict[str,
 
 # convert talk_to_robot_internal from dict generator into json generator
 def talk_to_robot(index, query: str, mode: str, history: List[Dict[str, str]], k: int = STANDARD_K, log: Callable = print):
-    yield from (json.dumps(block) for block in talk_to_robot_internal(index, query, mode, history, k, log))
+    session_id = str(uuid.uuid4())
+    budget_manager.create_budget(total_budget=10, user=session_id) # init $10 budget
+    yield from (json.dumps(block) for block in talk_to_robot_internal(index, query, mode, history, k, log, session_id=session_id))
 
 # wayyy simplified api
 def talk_to_robot_simple(index, query: str, log: Callable = print):
     res = {'response': ''}
-
-    for block in talk_to_robot_internal(index, query, "default", [], log = log):
+    session_id = str(uuid.uuid4())
+    budget_manager.create_budget(total_budget=10, user=session_id) # init $10 budget
+    for block in talk_to_robot_internal(index, query, "default", [], log = log,  session_id=session_id):
         if block['state'] == 'loading' and block['phase'] == 'semantic' and 'citations' in block:
             citations = {}
             for i, c in enumerate(block['citations']):

--- a/api/src/stampy_chat/chat.py
+++ b/api/src/stampy_chat/chat.py
@@ -29,7 +29,7 @@ CONTEXT_FRACTION = 0.5  # the (approximate) fraction of num_tokens to use for co
 ENCODER = tiktoken.get_encoding("cl100k_base")
 
 # initialize a budget manager to control costs for gpt-4/other llms
-budget_manager = litellm.BudgetManager(project_name="stamp_chat")
+budget_manager = litellm.BudgetManager(project_name="stampy_chat")
 
 DEBUG_PRINT = True
 


### PR DESCRIPTION
Addressing: 
https://github.com/StampyAI/stampy-chat/issues/47 
https://github.com/StampyAI/stampy-chat/issues/55 

This PR addresses two problems:
- Add support for 100+ LLMs
- Use a budget manager for limiting $ spend per session or per user 

## Add support for 100+ LLMs
using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion
## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"
messages = [{ "content": "Hello, how are you?","role": "user"}]
# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

```

## Use a budget manager for limiting $ spend per session or per user 
LiteLLM exposes a budget manager for each session/user 
- We init a budget manager 
- Check the budget manager before making completion calls
- Update with costs after making completion calls 
