### PR TITLE
Allow chat items to be deleted

### DIFF
--- a/api/src/stampy_chat/chat.py
+++ b/api/src/stampy_chat/chat.py
@@ -175,7 +175,7 @@ def make_memory(settings, history, callbacks):
         return_messages=True,
         callbacks=callbacks
     )
-    memory.set_messages(history)
+    memory.set_messages([i for i in history if i.get('role') != 'deleted'])
     return memory
 
 
@@ -192,16 +192,6 @@ def run_query(session_id: str, query: str, history: List[Dict], settings: Settin
     if callback:
         callbacks += [BroadcastCallbackHandler(callback)]
     chat_model = get_model(streaming=True, callbacks=callbacks, max_tokens=settings.max_response_tokens)
-
-    memory = LimitedConversationSummaryBufferMemory(
-        llm=get_model(),
-        max_token_limit=settings.history_tokens,
-        max_history=settings.maxHistory,
-        chat_memory=ChatMessageHistory(),
-        return_messages=True,
-        callbacks=callbacks
-    )
-    memory.set_messages(history)
 
     chain = LLMChain(
         llm=chat_model,

--- a/api/src/stampy_chat/db/session.py
+++ b/api/src/stampy_chat/db/session.py
@@ -48,17 +48,15 @@ class ItemAdder:
         self._last_save = time.time()
 
     def commit(self):
-        with Session(self.engine) as session:
-            try:
+        try:
+            with Session(self.engine) as session:
                 session.add_all(self.batch)
                 session.commit()
                 logger.debug('added %s items', len(self.batch))
-                self.batch = []
-            except SQLAlchemyError as e:
-                logger.warn('Got error when trying to commit to database: %s', e)
-                session.rollback()
-                raise e
+            self.batch = []
             self._last_save = time.time()
+        except SQLAlchemyError as e:
+            logger.warn('Got error when trying to commit to database: %s', e)
 
     def add(self, *items):
         """Add the provided items to the database, commiting them if needed."""
@@ -69,6 +67,4 @@ class ItemAdder:
 
     def __del__(self):
         logger.debug('cleaning up session')
-        if self.session:
-            self.commit()
-            self.session.close()
+        self.commit()

--- a/web/src/components/chat.tsx
+++ b/web/src/components/chat.tsx
@@ -164,9 +164,26 @@ const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
 
   return (
     <ul className="flex-auto">
-      {entries.map((entry, i) => (
-        <EntryTag entry={entry} key={i} />
-      ))}
+      {entries.map(
+        (entry, i) =>
+          !entry.deleted && (
+            <li className="group relative flex" key={i}>
+              <EntryTag entry={entry} />
+              <span
+                className="delete-item absolute right-5 hidden cursor-pointer group-hover:block"
+                onClick={() => {
+                  const entry = entries[i];
+                  if (entry !== undefined) {
+                    entry.deleted = true;
+                    setEntries([...entries]);
+                  }
+                }}
+              >
+                X
+              </span>
+            </li>
+          )
+      )}
       <SearchBox search={search} onQuery={onQuery} />
 
       {last_entry}

--- a/web/src/components/chat.tsx
+++ b/web/src/components/chat.tsx
@@ -179,7 +179,7 @@ const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
                   }
                 }}
               >
-                X
+                ✕
               </span>
             </li>
           )

--- a/web/src/components/entry.tsx
+++ b/web/src/components/entry.tsx
@@ -13,60 +13,50 @@ import TextareaAutosize from "react-textarea-autosize";
 
 export const User = ({ entry }: { entry: UserEntry }) => {
   return (
-    <li className="mt-1 mb-2 flex">
-      <TextareaAutosize
-        className="flex-1 resize-none border border-gray-300 px-1"
-        value={entry.content}
-      />
-    </li>
+    <TextareaAutosize
+      className="flex-1 resize-none border border-gray-300 px-1"
+      value={entry.content}
+    />
   );
 };
 
 export const Error = ({ entry }: { entry: ErrorMessage }) => {
   return (
-    <li>
-      <p className="border border-red-500 bg-red-100 px-1 text-red-800">
-        {" "}
-        {entry.content}{" "}
-      </p>
-    </li>
+    <p className="border border-red-500 bg-red-100 px-1 text-red-800">
+      {" "}
+      {entry.content}{" "}
+    </p>
   );
 };
 
 export const Assistant = ({ entry }: { entry: AssistantEntryType }) => {
-  return (
-    <li>
-      <AssistantEntry entry={entry} />
-    </li>
-  );
+  return <AssistantEntry entry={entry} />;
 };
 
 export const Stampy = ({ entry }: { entry: StampyMessage }) => {
   return (
-    <li>
-      <div
-        className="my-7 rounded bg-slate-500 px-4 py-0.5 text-slate-50"
-        style={{
-          marginLeft: "auto",
-          marginRight: "auto",
-          maxWidth: "99.8%",
-        }}
-      >
-        <div>
-          <GlossarySpan content={entry.content} />
-        </div>
-        <div className="mb-3 flex justify-end">
-          <a
-            href={entry.url}
-            target="_blank"
-            className="flex items-center space-x-1"
-          >
-            <span>aisafety.info</span>
-            <Image src={logo} alt="aisafety.info logo" width={19} />
-          </a>
-        </div>
+    <div
+      className="my-7 rounded bg-slate-500 px-4 py-0.5 text-slate-50"
+      style={{
+        marginLeft: "auto",
+        marginRight: "auto",
+        maxWidth: "99.8%",
+      }}
+    >
+      <div>
+        <GlossarySpan content={entry.content} />
       </div>
-    </li>
+      <div className="mb-3 flex justify-end">
+        <a
+          href={entry.url}
+          target="_blank"
+          className="flex items-center space-x-1"
+        >
+          <span>aisafety.info</span>
+          <Image src={logo} alt="aisafety.info logo" width={19} />
+        </a>
+      </div>
+    </div>
   );
 };
 

--- a/web/src/hooks/useSearch.ts
+++ b/web/src/hooks/useSearch.ts
@@ -16,8 +16,9 @@ const MAX_FOLLOWUPS = 4;
 const DATA_HEADER = "data: ";
 const EVENT_END_HEADER = "event: close";
 
+type EntryRole = "error" | "stampy" | "assistant" | "user" | "deleted";
 type HistoryEntry = {
-  role: "error" | "stampy" | "assistant" | "user";
+  role: EntryRole;
   content: string;
 };
 
@@ -223,7 +224,7 @@ export const runSearch = async (
     const history = entries
       .filter((entry) => entry.role !== "error")
       .map((entry) => ({
-        role: entry.role,
+        role: (entry.deleted ? "deleted" : entry.role) as EntryRole,
         content: entry.content.trim(),
       }));
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -17,6 +17,7 @@ export type Entry = UserEntry | AssistantEntry | ErrorMessage | StampyMessage;
 export type UserEntry = {
   role: "user";
   content: string;
+  deleted?: boolean;
 };
 
 export type AssistantEntry = {
@@ -24,17 +25,20 @@ export type AssistantEntry = {
   content: string;
   citations: Citation[];
   citationsMap: Map<string, Citation>;
+  deleted?: boolean;
 };
 
 export type ErrorMessage = {
   role: "error";
   content: string;
+  deleted?: boolean;
 };
 
 export type StampyMessage = {
   role: "stampy";
   content: string;
   url: string;
+  deleted?: boolean;
 };
 
 export type SearchResult = {


### PR DESCRIPTION
I was uncertain whether to just delete any removed history items and totally forget about them, or to just soft delete them. The hard delete is nice in that it's a lot simpler, but has the downside that it would totally mess up the history which gets logged to the database. I considered having a proper changelog type thingy, which would allow one to recreate the whole session, but decided against it as it would get very complicated. On the other hand, the current logging implementation adds a number saying which interaction this is, based on the history length. An alternative to this would be to always query the database before writing, to get the number of interactions in this session.
I went with a soft delete, as that can be used later on to make an interactive session viewer, which is something I wanted to do anyway, to play about with seeing how different prompts and settings effect things.

<img width="786" alt="image" src="https://github.com/StampyAI/stampy-chat/assets/3942390/9c7a58db-f362-4fe2-ab77-6b3a3405902a">
