### PR TITLE
proper removal of previous entries

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -44,10 +44,14 @@ def semantic():
 @app.route('/chat', methods=['POST'])
 @cross_origin()
 def chat():
-    query = request.json.get('query')
+    query = request.json.get('query', None)
     session_id = request.json.get('sessionId')
     history = request.json.get('history', [])
     settings = request.json.get('settings', {})
+
+    if query is None:
+        query = history[-1].get('content')
+        history = history[:-1]
 
     def formatter(item):
         if isinstance(item, Exception):

--- a/web/src/components/assistant.tsx
+++ b/web/src/components/assistant.tsx
@@ -5,27 +5,25 @@ import type { Citation, AssistantEntry as AssistantType } from "../types";
 
 export const AssistantEntry: React.FC<{ entry: AssistantType }> = ({
   entry,
-}) => {
-  return (
-    <div className="mt-3 mb-8">
-      {entry.content.split("\n").map((paragraph, i) => (
-        <CitationsBlock
-          key={i}
-          text={paragraph}
-          citations={entry.citationsMap}
-          textRenderer={(t) => <GlossarySpan content={t} />}
-        />
-      ))}
-      <ul className="mt-5">
-        {
-          // show citations
-          Array.from(entry.citationsMap.values()).map((citation) => (
-            <li key={citation.index}>
-              <ShowCitation citation={citation} />
-            </li>
-          ))
-        }
-      </ul>
-    </div>
-  );
-};
+}) => (
+  <div className="mt-3 mb-8">
+    {entry.content.split("\n").map((paragraph, i) => (
+      <CitationsBlock
+        key={i}
+        text={paragraph}
+        citations={entry.citationsMap}
+        textRenderer={(t) => <GlossarySpan content={t} />}
+      />
+    ))}
+    <ul className="mt-5">
+      {
+        // show citations
+        Array.from(entry.citationsMap.values()).map((citation) => (
+          <li key={citation.index}>
+            <ShowCitation citation={citation} />
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+);

--- a/web/src/components/assistant.tsx
+++ b/web/src/components/assistant.tsx
@@ -11,19 +11,18 @@ export const AssistantEntry: React.FC<{ entry: AssistantType }> = ({
       <CitationsBlock
         key={i}
         text={paragraph}
-        citations={entry.citationsMap}
+        citations={entry.citationsMap || new Map()}
         textRenderer={(t) => <GlossarySpan content={t} />}
       />
     ))}
     <ul className="mt-5">
-      {
+      {entry.citationsMap &&
         // show citations
         Array.from(entry.citationsMap.values()).map((citation) => (
           <li key={citation.index}>
             <ShowCitation citation={citation} />
           </li>
-        ))
-      }
+        ))}
     </ul>
   </div>
 );

--- a/web/src/components/chat.tsx
+++ b/web/src/components/chat.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from "react";
-import { queryLLM, getStampyContent, runSearch } from "../hooks/useSearch";
+import {
+  queryLLM,
+  getStampyContent,
+  EntryRole,
+  HistoryEntry,
+} from "../hooks/useSearch";
+import { initialQuestions } from "../settings";
 
 import type {
   CurrentSearch,
@@ -8,6 +14,7 @@ import type {
   AssistantEntry as AssistantEntryType,
   LLMSettings,
   Followup,
+  SearchResult,
 } from "../types";
 import useCitations from "../hooks/useCitations";
 import { SearchBox } from "../components/searchbox";
@@ -41,6 +48,9 @@ function scroll30() {
   window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
 }
 
+const randomQuestion = () =>
+  initialQuestions[Math.floor(Math.random() * initialQuestions.length)] || "";
+
 export const ChatResponse = ({
   current,
   defaultElem,
@@ -73,6 +83,22 @@ export const ChatResponse = ({
   }
 };
 
+const makeHistory = (query: string, entries: Entry[]): HistoryEntry[] => {
+  const getRole = (entry: Entry): EntryRole => {
+    if (entry.deleted) return "deleted";
+    if (entry.role === "stampy") return "assistant";
+    return entry.role;
+  };
+
+  const history = entries
+    .filter((entry) => entry.role !== "error")
+    .map((entry) => ({
+      role: getRole(entry),
+      content: entry.content.trim(),
+    }));
+  return [...history, { role: "user", content: query }];
+};
+
 type ChatParams = {
   sessionId: string;
   settings: LLMSettings;
@@ -82,7 +108,11 @@ type ChatParams = {
 
 const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
   const [entries, setEntries] = useState<Entry[]>([]);
+
+  const [query, setQuery] = useState(randomQuestion());
   const [current, setCurrent] = useState<CurrentSearch>();
+  const [followups, setFollowups] = useState<Followup[]>([]);
+  const [controller, setController] = useState(new AbortController());
   const { citations, setEntryCitations } = useCitations();
 
   const updateCurrent = (current: CurrentSearch) => {
@@ -94,46 +124,72 @@ const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
     }
   };
 
-  const addEntry = (entry: Entry) => {
+  const addResult = (query: string, { result, followups }: SearchResult) => {
+    const userEntry = { role: "user", content: query };
     setEntries((prev) => {
-      const entries = [...prev, entry];
+      const entries = [...prev, userEntry, result] as Entry[];
       if (onNewEntry) {
         onNewEntry(entries);
       }
       return entries;
     });
+    setFollowups(followups || []);
+    setQuery("");
+    scroll30();
   };
 
-  const search = async (
-    query: string,
-    query_source: "search" | "followups",
-    enable: (f_set: Followup[] | ((fs: Followup[]) => Followup[])) => void,
-    controller: AbortController
-  ) => {
-    // clear the query box, append to entries
-    const userEntry: Entry = {
-      role: "user",
-      content: query_source === "search" ? query : query.split("\n", 2)[1]!,
+  const withController =
+    (f: any) =>
+    (...args: any) => {
+      const controller = new AbortController();
+      setController(controller);
+      return f(controller, ...args);
     };
 
-    const { result, followups } = await runSearch(
-      query,
-      query_source,
+  const search = async (controller: AbortController, query: string) => {
+    // clear the query box, append to entries
+    setFollowups([]);
+
+    const history = makeHistory(query, entries);
+
+    const result = await queryLLM(
       settings,
-      entries,
+      history,
       updateCurrent,
       sessionId,
       controller
     );
-    if (result.content !== "aborted") {
-      addEntry(userEntry);
-      addEntry(result);
-      enable(followups || []);
-      scroll30();
-    } else {
-      enable([]);
+
+    if (result.result.content !== "aborted") {
+      addResult(query, result);
     }
     setCurrent(undefined);
+  };
+
+  const fetchFollowup = async (
+    controller: AbortController,
+    followup: Followup
+  ) => {
+    const result = await getStampyContent(followup.pageid, controller);
+    addResult(followup.text, result);
+  };
+
+  const deleteEntry = (i: number) => {
+    const entry = entries[i];
+    if (entry === undefined) {
+      return;
+    } else if (
+      i === entries.length - 1 &&
+      ["assistant", "stampy"].includes(entry.role)
+    ) {
+      const prev = entries[i - 1];
+      if (prev !== undefined) setQuery(prev.content);
+      setEntries(entries.slice(0, i - 1));
+      setFollowups([]);
+    } else {
+      entry.deleted = true;
+      setEntries([...entries]);
+    }
   };
 
   return (
@@ -145,20 +201,27 @@ const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
               <EntryTag entry={entry} />
               <span
                 className="delete-item absolute right-5 hidden cursor-pointer group-hover:block"
-                onClick={() => {
-                  const entry = entries[i];
-                  if (entry !== undefined) {
-                    entry.deleted = true;
-                    setEntries([...entries]);
-                  }
-                }}
+                onClick={() => deleteEntry(i)}
               >
                 ✕
               </span>
             </li>
           )
       )}
-      <SearchBox search={search} onQuery={onQuery} />
+
+      <Followups
+        followups={followups}
+        onClick={withController(fetchFollowup)}
+      />
+      <SearchBox
+        search={withController(search)}
+        query={query}
+        onQuery={(v: string) => {
+          setQuery(v);
+          onQuery && onQuery(v);
+        }}
+        abortSearch={() => controller.abort()}
+      />
       <ChatResponse
         current={current}
         defaultElem={
@@ -170,3 +233,24 @@ const Chat = ({ sessionId, settings, onQuery, onNewEntry }: ChatParams) => {
 };
 
 export default Chat;
+
+const Followups = ({
+  followups,
+  onClick,
+}: {
+  followups: Followup[];
+  onClick: (f: Followup) => void;
+}) => (
+  <div className="mt-1 flex flex-col items-end">
+    {followups.map((followup: Followup, i: number) => (
+      <li key={i}>
+        <button
+          className="my-1 border border-gray-300 px-1"
+          onClick={() => onClick(followup)}
+        >
+          <span> {followup.text} </span>
+        </button>
+      </li>
+    ))}
+  </div>
+);

--- a/web/src/components/searchbox.tsx
+++ b/web/src/components/searchbox.tsx
@@ -6,35 +6,14 @@ import TextareaAutosize from "react-textarea-autosize";
 import dynamic from "next/dynamic";
 
 const SearchBoxInternal: React.FC<{
-  search: (
-    query: string,
-    query_source: "search" | "followups",
-    enable: (f_set: Followup[] | ((fs: Followup[]) => Followup[])) => void,
-    controller: AbortController
-  ) => void;
-  onQuery?: (q: string) => any;
-}> = ({ search, onQuery }) => {
-  const initial_query =
-    initialQuestions[Math.floor(Math.random() * initialQuestions.length)] || "";
-
-  const [query, setQuery] = useState(initial_query);
+  query: string;
+  search: (query: string) => void;
+  abortSearch: () => void;
+  onQuery: (q: string) => any;
+}> = ({ query, search, onQuery, abortSearch }) => {
   const [loading, setLoading] = useState(false);
-  const [followups, setFollowups] = useState<Followup[]>([]);
-  const [controller, setController] = useState(new AbortController());
 
   const inputRef = React.useRef<HTMLTextAreaElement>(null);
-
-  // because everything is async, I can't just manually set state at the
-  // point we do a search. Instead it needs to be passed into the search
-  // method, for some reason.
-  const enable =
-    (controller: AbortController) =>
-    (f_set: Followup[] | ((fs: Followup[]) => Followup[])) => {
-      if (!controller.signal.aborted) setQuery("");
-
-      setLoading(false);
-      setFollowups(f_set);
-    };
 
   useEffect(() => {
     // set focus on the input box
@@ -49,61 +28,41 @@ const SearchBoxInternal: React.FC<{
     inputRef.current.selectionEnd = inputRef.current.textLength;
   }, []);
 
-  const runSearch =
-    (query: string, searchtype: "search" | "followups") => () => {
-      if (loading || query.trim() === "") return;
+  const runSearch = (query: string) => async () => {
+    if (loading || query.trim() === "") return;
 
-      setLoading(true);
-      const controller = new AbortController();
-      setController(controller);
-      search(query, searchtype, enable(controller), controller);
-    };
-  const cancelSearch = () => controller.abort();
+    setLoading(true);
+    await search(query);
+    setLoading(false);
+  };
+
+  const cancelSearch = () => {
+    abortSearch();
+    setLoading(false);
+  };
 
   return (
     <>
-      <div className="mt-1 flex flex-col items-end">
-        {" "}
-        {followups.map((followup, i) => {
-          return (
-            <li key={i}>
-              <button
-                className="my-1 border border-gray-300 px-1"
-                onClick={runSearch(
-                  followup.pageid + "\n" + followup.text,
-                  "followups"
-                )}
-              >
-                <span> {followup.text} </span>
-              </button>
-            </li>
-          );
-        })}
-      </div>
-
       <div className="mt-1 mb-2 flex">
         <TextareaAutosize
           className="flex-1 resize-none border border-gray-300 px-1"
           ref={inputRef}
           value={query}
-          onChange={(e) => {
-            setQuery(e.target.value);
-            onQuery && onQuery(e.target.value);
-          }}
+          onChange={(e) => onQuery(e.target.value)}
           onKeyDown={(e) => {
             // if <esc>, blur the input box
             if (e.key === "Escape") e.currentTarget.blur();
             // if <enter> without <shift>, submit the form (if it's not empty)
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
-              runSearch(query, "search")();
+              runSearch(query)();
             }
           }}
         />
         <button
           className="ml-2"
           type="button"
-          onClick={loading ? cancelSearch : runSearch(query, "search")}
+          onClick={loading ? cancelSearch : runSearch(query)}
         >
           {loading ? "Cancel" : "Search"}
         </button>

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -2,9 +2,7 @@ import { type NextPage } from "next";
 import { useState, useEffect } from "react";
 import Link from "next/link";
 
-import { queryLLM, getStampyContent, runSearch } from "../hooks/useSearch";
 import useSettings from "../hooks/useSettings";
-import type { Mode } from "../types";
 import Page from "../components/page";
 import Chat from "../components/chat";
 import { Controls } from "../components/controls";

--- a/web/src/pages/semantic.tsx
+++ b/web/src/pages/semantic.tsx
@@ -15,8 +15,8 @@ const ignoreAbort = (error: Error) => {
 };
 
 const Semantic: NextPage = () => {
-  const [query, setQuery] = useState(randomQuestion());
-  const [controller, setController] = useState(new AbortController());
+  const [query, setQuery] = useState(() => randomQuestion());
+  const [controller, setController] = useState(() => new AbortController());
   const [results, setResults] = useState<SemanticEntry[]>([]);
 
   const semantic_search = async (query: string) => {

--- a/web/src/pages/tester.tsx
+++ b/web/src/pages/tester.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import Page from "../components/page";
 
 import useCitations from "../hooks/useCitations";
-import { queryLLM, getStampyContent, runSearch } from "../hooks/useSearch";
+import { queryLLM, getStampyContent } from "../hooks/useSearch";
 import useSettings from "../hooks/useSettings";
 import { initialQuestions } from "../settings";
 import type {
@@ -63,9 +63,8 @@ const Tester: NextPage = () => {
       selected,
       index,
       query: queryLLM(
-        question,
         settings,
-        [],
+        [{ role: "user", content: question }],
         updater(index),
         sessionId,
         controller

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -24,7 +24,7 @@ export type AssistantEntry = {
   role: "assistant";
   content: string;
   citations?: Citation[];
-  citationsMap: Map<string, Citation>;
+  citationsMap?: Map<string, Citation>;
   deleted?: boolean;
 };
 


### PR DESCRIPTION
This is mainly a lot of reshuffling of the code. The previous code would display a history of previous interactions, each of which could be deleted, but this wouldn't have any effect on the current search. Which was annoying when you wanted to delete the last response and try again - it would delete it, but then you'd still have to copy your search phrase over.
Now when the last item is deleted, it will return to editing the previous query