### PR TITLE
Add page for randomized user testing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,8 @@ from stampy_chat.settings import Settings
 from stampy_chat.chat import run_query
 from stampy_chat.callbacks import stream_callback
 from stampy_chat.citations import get_top_k_blocks
+from stampy_chat.db.session import make_session
+from stampy_chat.db.models import Rating
 
 
 # ---------------------------------- web setup ---------------------------------
@@ -95,6 +97,24 @@ def human(id):
     return Response(text, mimetype='application/json')
 
 # ------------------------------------------------------------------------------
+
+@app.route('/ratings', methods=['POST'])
+@cross_origin()
+def ratings():
+    session_id = request.json.get('sessionId')
+    settings = request.json.get('settings', {})
+    score = request.json.get('score')
+
+    if not session_id or score is None:
+        return Response('{"error": "missing params}', 400, mimetype='application/json')
+
+    with make_session() as s:
+        s.add(Rating(session_id=session_id, score=score, settings=json.dumps(settings)))
+        s.commit()
+
+    return jsonify({'status': 'ok'})
+
+
 
 if __name__ == '__main__':
     app.run(debug=True, port=FLASK_PORT)

--- a/api/migrations/versions/5813982e9665_ratings_table.py
+++ b/api/migrations/versions/5813982e9665_ratings_table.py
@@ -1,0 +1,33 @@
+"""Ratings table
+
+Revision ID: 5813982e9665
+Revises: 78806d965229
+Create Date: 2023-11-06 17:31:47.814226
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from stampy_chat.db.models import UUID
+
+# revision identifiers, used by Alembic.
+revision = '5813982e9665'
+down_revision = '78806d965229'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ratings',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('session_id', UUID(length=16), nullable=False),
+        sa.Column('score', sa.Integer(), nullable=False),
+        sa.Column('comment', mysql.LONGTEXT(), nullable=True),
+        sa.Column('settings', mysql.LONGTEXT(), nullable=False),
+        sa.Column('date_created', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+def downgrade() -> None:
+    op.drop_table('rating')

--- a/api/src/stampy_chat/db/models.py
+++ b/api/src/stampy_chat/db/models.py
@@ -90,3 +90,26 @@ class Interaction(Base):
 
     def __repr__(self) -> str:
         return f"Interaction(session={self.session_id!r}, no={self.interaction_no!r}, query={self.query!r}, response={self.response!r})"
+
+
+class Rating(Base):
+    __tablename__ = "ratings"
+
+    id: Mapped[int] = mapped_column("id", primary_key=True)
+
+    # The session_id is set once per session, so can be easily used to extract whole histories
+    session_id: Mapped[str] = mapped_column(UUID(), default=uuid.uuid4)
+
+    # the user provided score
+    score: Mapped[int] = mapped_column(Integer)
+
+    # An optional comment
+    comment: Mapped[Optional[str]] = mapped_column(LONGTEXT)
+
+    # The settings object, serialized to JSON
+    settings: Mapped[str] = mapped_column(LONGTEXT)
+
+    date_created: Mapped[datetime] = mapped_column(DateTime, default=func.now())
+
+    def __repr__(self) -> str:
+        return f"Rating(session={self.session_id!r}, score={self.score!r})"

--- a/web/src/components/settings.tsx
+++ b/web/src/components/settings.tsx
@@ -37,18 +37,18 @@ export const ChatSettings = ({
         onChange={(event: ChangeEvent) => {
           const value = (event.target as HTMLInputElement).value;
           const { maxNumTokens, topKBlocks } =
-            MODELS[value as keyof typeof MODELS];
+            MODELS[value as keyof typeof MODELS] || {};
           const prevNumTokens =
-            MODELS[settings.completions as keyof typeof MODELS].maxNumTokens;
+            MODELS[settings.completions as keyof typeof MODELS]?.maxNumTokens;
           const prevTopKBlocks =
-            MODELS[settings.completions as keyof typeof MODELS].topKBlocks;
+            MODELS[settings.completions as keyof typeof MODELS]?.topKBlocks;
 
           if (settings.maxNumTokens === prevNumTokens) {
             changeVal("maxNumTokens", maxNumTokens);
           } else {
             changeVal(
               "maxNumTokens",
-              Math.min(settings.maxNumTokens || 0, maxNumTokens)
+              Math.min(settings.maxNumTokens || 0, maxNumTokens || 0)
             );
           }
           if (settings.topKBlocks === prevTopKBlocks) {
@@ -86,7 +86,7 @@ export const ChatSettings = ({
         field="maxNumTokens"
         label="Tokens"
         min="1"
-        max={MODELS[settings.completions as keyof typeof MODELS].maxNumTokens}
+        max={MODELS[settings.completions as keyof typeof MODELS]?.maxNumTokens}
         updater={updateNum("maxNumTokens")}
       />
       <NumberInput

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -56,3 +56,12 @@ ol {
 .glossary-link {
   @apply underline hover:no-underline;
 }
+
+.rate-container {
+  margin-top: 20px;
+}
+
+.rate-button {
+  width: 2.5em;
+  margin: 0.5em;
+}


### PR DESCRIPTION
This adds a new page that has the option to rate the current session from 1-5, where the session's settings are randomized. This will hopefully allow to try out various settings and see which are better. I considered also adding this rating option to the main chat, but thought that it's probably better to first see whether it makes sense