### PR TITLE
Fix citation format to place period before citation numbers

### DIFF
--- a/api/src/stampy_chat/settings.py
+++ b/api/src/stampy_chat/settings.py
@@ -30,7 +30,7 @@ HISTORY_SUMMARIZE_PROMPT = (
 QUESTION_PROMPT = (
     "In your answer, please cite any claims you make back to each source "
     "using the format: [1], [2], etc. If you use multiple sources to make a claim "
-    "cite all of them. For example: \"AGI is concerning [1, 3, 8].\"\n\n"
+    "cite all of them. For example: \"AGI is concerning. [1, 3, 8]\" (note the period placement)\n\n"
 )
 PROMPT_MODES = {
     'default': "",


### PR DESCRIPTION
This was simply a matter of changing one line in stampy-chat/api/src/stampy_chat/settings.py

```
QUESTION_PROMPT = (
    "In your answer, please cite any claims you make back to each source "
    "using the format: [1], [2], etc. If you use multiple sources to make a claim "
    "cite all of them. For example: \"AGI is concerning [1, 3, 8].\"\n\n"
)
```

to

```
QUESTION_PROMPT = (
    "In your answer, please cite any claims you make back to each source "
    "using the format: [1], [2], etc. If you use multiple sources to make a claim "
    "cite all of them. For example: \"AGI is concerning. [1, 3, 8]\" (note the period placement)\n\n"
)
```

I am unable to run this codebase on my local machine (due to dependencies issues caused by an outdated MacOS, I think), but I'm 98% confident this will work, since the reason for the unwanted behaviour was so explicit.