### PR TITLE
Handle stampy messages in chat

### DIFF
--- a/api/src/stampy_chat/chat.py
+++ b/api/src/stampy_chat/chat.py
@@ -343,6 +343,8 @@ def merge_history(history):
             role = "human"
         if role == "assistant":
             role = "ai"
+        if role == "stampy":
+            role = "ai"
         return {"type": role, "data": h}
 
     return messages_from_dict([transform(m) for m in messages])

--- a/api/src/stampy_chat/chat.py
+++ b/api/src/stampy_chat/chat.py
@@ -344,7 +344,16 @@ def merge_history(history):
         if role == "assistant":
             role = "ai"
         if role == "stampy":
-            role = "ai"
+            # Stampy answers (i.e. human written answers) aren't clearly human or ai.
+            # They are "human" in the sense that humans wrote them,
+            # but they are also "ai" in the sense that they are answers to questions.
+            # Importantly, LLM providers/langchain may expect LLM messages to be in a specific format or have restrictions.
+            # For example, Anthropic seems to require that AI messages don't have trailing whitespace (https://github.com/microsoft/autogen/issues/6167)
+            # As there seem to be less restrictions on human messages, we'll use that
+            # See list of message types: https://python.langchain.com/api_reference/_modules/langchain_core/messages/utils.html#messages_from_dict
+            # Anthropic seems to only accept "human" and "ai" messages:
+            # https://github.com/langchain-ai/langchain/blob/a79998800c2f0dc17347fcaee4dab77681235490/libs/partners/anthropic/langchain_anthropic/chat_models.py#L74
+            role = "human"
         return {"type": role, "data": h}
 
     return messages_from_dict([transform(m) for m in messages])


### PR DESCRIPTION
Addresses #158 . See code comment for approach rationale.

Another approach tried was to strip whitespace from the end of stampy messages in order to be able to label them as `ai` messages (as this is what Anthropic requires), but trimming the messages seemed a bit complicated. They would could be trimmed in the `LimitedConversationSummaryBufferMemory.prune` function that calls `get_num_tokens_from_messages` (which has the whitespace restriction) but then the token count not match the messages in the history. And trimming before `LimitedConversationSummaryBufferMemory.prune` seems to be poor cohesion. 