### PR TITLE
[Claude] MCP server: get_doc, recent search, text cleaning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
+      - name: Init submodules (non-recursive)
+        run: git submodule update --init
       - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ard"]
+	path = ard
+	url = https://github.com/StampyAI/alignment-research-dataset.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,9 @@ Javascript tools - excerpt from web/package.json:
   ...
 }
 ```
+
+
+## Living Memory
+
+- `session 137` 2026-03-27: observed stampy-chat MCP server at api/mcp_server.py runs on port 3002 via FastMCP HTTP transport. Uses Pinecone for semantic search (via stampy_chat.citations) and MySQL alignment_research_dataset DB for full-text retrieval. ARD text cleaning imported via importlib.util from ard symlink (bypasses heavy align_data.__init__). ARD MySQL `authors` field is comma-separated string, not list. Article text can be huge (19MB raw); clean_text from ard/align_data/embeddings/clean.py strips base64/SVG/Plotly; 99th percentile cleaned length ~130k chars. `watchexec -w mcp_server.py -r` for dev reload but races on port binding -- use --restart-timeout 2s or kill old process first. (stampy-mcp-architecture).
+  ttl: 2

--- a/api/mcp_server.py
+++ b/api/mcp_server.py
@@ -2,102 +2,199 @@
 """
 Stampy Chat MCP Server
 
-Provides RAG search tools via Model Context Protocol for remote access.
+Provides search and retrieval tools for AI alignment research via MCP.
+Sources: LessWrong, Alignment Forum, curated arxiv safety papers, EA Forum, blogs, more.
+~25k articles. Updated within days of publication.
 """
 
-from datetime import datetime
+import importlib.util
+from datetime import datetime, timedelta
+from pathlib import Path
 from fastmcp import FastMCP
+from sqlalchemy import create_engine, table, column, select
 from stampy_chat.citations import get_top_k_blocks, Block
 from stampy_chat.prompts import format_blocks
 from stampy_chat import logging
+from stampy_chat.env import DB_CONNECTION_URI
 
 logger = logging.getLogger(__name__)
 
-# Initialize MCP server
 mcp = FastMCP("Stampy Backend RAG")
 
+# alignment_research_dataset lives in the same MySQL instance, different db
+ARD_URI = DB_CONNECTION_URI.rsplit("/", 1)[0] + "/alignment_research_dataset"
+ard_engine = create_engine(ARD_URI, echo=False)
 
-@mcp.tool
-def search_alignment_research(
-    query: str, k: int = 20, filter: dict | None = None, format: str = "formatted",
-    snippets_per_doc: int = 1,
-) -> str | list[dict]:
-    """
-    Search AI alignment research database for relevant content.
+articles = table("articles",
+    column("hash_id"), column("title"), column("url"),
+    column("source"), column("authors"), column("text"),
+    column("date_published"),
+)
 
-    Args:
-        query: The search query string
-        k: Number of results to return (default: 20, max: 50)
-        format: Output format - "formatted" returns XML citation blocks, "json" returns raw dicts (default: "formatted")
-        snippets_per_doc: Max chunks to return per document (default: 1). Higher values return more context from same doc.
-        filter: Optional Pinecone metadata filter dict. Supports operators: $eq, $ne, $gt, $gte, $lt, $lte, $in, $nin, $and, $or
+# Import ARD text cleaner directly (bypasses align_data.__init__ and its heavy deps)
+_clean_spec = importlib.util.spec_from_file_location(
+    "ard_clean", Path(__file__).resolve().parent.parent / "ard" / "align_data" / "embeddings" / "clean.py"
+)
+_clean_mod = importlib.util.module_from_spec(_clean_spec)
+_clean_spec.loader.exec_module(_clean_mod)
+clean_text = _clean_mod.clean_text
 
-                Available metadata fields:
-                - title (str): Document title
-                - authors (list[str]): Author names. Use $in for membership, eg {"authors": {"$in": ["Eliezer Yudkowsky"]}}
-                - date_published (int|str): Unix timestamp or ISO date string (eg "2020-01-01", "2020-01-01T00:00:00Z"). Use $gte/$lte for date ranges
-                - url (str): Source URL
-                - source (str): Data source, eg "alignmentforum", "lesswrong", "arxiv"
-                - needs_tech (bool): True = doc has formatting issues, awaiting reimport
-                - quality_score (int): Content quality/relevance 0-10
+# 99th percentile cleaned article length is ~130k chars
+MAX_DOC_CHARS = 130_000
 
-                Examples:
-                {"quality_score": {"$gte": 8}}
-                {"needs_tech": false}
-                {"date_published": {"$gte": 1577836800}}  (Jan 1, 2020)
-                {"date_published": {"$gte": "2020-01-01"}}  (same, using ISO date)
-                {"$and": [{"date_published": {"$gte": 1577836800}}, {"quality_score": {"$gte": 7}}]}
 
-    Returns:
-        If format="formatted": Formatted XML blocks with search results and citations
-        If format="json": List of block dictionaries with metadata and text
-    """
-    # Debug logging to see what type we actually receive
-    logger.info(f"MCP search raw filter parameter: type={type(filter)} value={filter!r}")
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-    # Convert ISO dates and remap quality_* fields to internal miri_* fields
+def _search(query, k=20, filter=None, format="formatted", snippets_per_doc=1):
+    """Core search logic shared by search and recent tools."""
     if filter:
         filter = _convert_date_fields(filter)
         filter = _remap_quality_fields(filter)
 
-    logger.info(f"MCP search request: query='{query}' k={k} format={format} snippets_per_doc={snippets_per_doc} filter={filter}")
+    logger.info(f"MCP search: query='{query}' k={k} format={format} snippets_per_doc={snippets_per_doc} filter={filter}")
 
-    # Clamp to reasonable bounds
     k = max(1, min(50, k))
     snippets_per_doc = max(1, min(10, snippets_per_doc))
 
-    try:
-        blocks = get_top_k_blocks(query, k, filter, snippets_per_doc)
-        logger.info(f"MCP search returned {len(blocks)} results")
+    blocks = get_top_k_blocks(query, k, filter, snippets_per_doc)
+    logger.info(f"MCP search returned {len(blocks)} results")
 
-        if format == "json":
-            return [dict(block) for block in blocks]
-        else:
-            return format_blocks(blocks)
-    except Exception as e:
-        logger.error(f"MCP search error: {e}", exc_info=True)
-        if format == "json":
-            raise
-        else:
-            return f"<error>Search failed: {str(e)}</error>"
+    if format == "json": return [dict(b) for b in blocks]
+    return format_blocks(blocks)
 
+
+def _get_article(*, id=None, url=None, title=None):
+    """Look up a single article using SQLAlchemy Core (no string building)."""
+    q = select(articles).limit(1)
+    if id: q = q.where(articles.c.hash_id == id)
+    if title: q = q.where(articles.c.title == title)
+    if url:
+        escaped = url.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        q = q.where(articles.c.url.like(f"%{escaped}%", escape="\\"))
+
+    with ard_engine.connect() as conn:
+        return conn.execute(q).mappings().first()
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+@mcp.tool
+def lw_af_arxivsafety_search(
+    query: str, k: int = 20, filter: dict | None = None, format: str = "formatted",
+    snippets_per_doc: int = 1,
+) -> str | list[dict]:
+    """Semantic search over 25k AI safety posts from LessWrong, Alignment Forum, arxiv (curated safety-relevant subset), EA Forum, blogs, and more. Updated within days of publication. Use for: finding prior alignment work, checking if an idea has been explored, retrieving specific researchers' writings, understanding current thinking on safety topics, finding counterarguments or failure modes for alignment proposals.
+
+Key researchers: John Wentworth (johnswentworth; natural abstractions, natural latents, research methodology), Richard Ngo ("Richard Ngo"; coalitional/scale-free agency, AI governance), Abram Demski (abramdemski; logical induction, embedded agency, decision theory), Vanessa Kosoy (infra-Bayesianism, learning-theoretic alignment). Also covers: mechanistic interpretability, singular learning theory, computational mechanics, governance/policy, RLHF safety, scalable oversight, and more.
+
+Filters: author, date range, source (lesswrong/alignmentforum/arxiv), quality score. Use filter={"authors": {"$in": ["Name"]}} for author search, filter={"date_published": {"$gte": "2024-01-01"}} for date ranges.
+
+    Args:
+        query: Natural language search query. Semantic search, so describe what you're looking for.
+        k: Number of results (unset=20, max 50)
+        format: unset="formatted" (XML with citations) or "json" (raw dicts with hash_id)
+        snippets_per_doc: default 1, max 10
+        filter: Pinecone metadata filter. Fields: title, authors, date_published (int|ISO str), url, source, needs_tech, quality_score (0-10). Operators: $eq $ne $gt $gte $lt $lte $in $nin $and $or.
+    """
+    return _search(query, k, filter, format, snippets_per_doc)
+
+
+@mcp.tool
+def lw_af_arxivsafety_recent(
+    query: str, days: int = 90, k: int = 20, filter: dict | None = None,
+    format: str = "formatted", snippets_per_doc: int = 1,
+) -> str | list[dict]:
+    """Search recent AI safety posts (default: last 90 days). Same corpus as lw_af_arxivsafety_search but pre-filtered to recent content. Use when you need current work, recent developments, or want to check what's been published lately on a topic.
+
+    Args:
+        query: Natural language search query.
+        days: How far back to search, unset=90.
+        k: Number of results (unset=20, max 50)
+        format: unset="formatted" (XML) or "json" (raw dicts)
+        snippets_per_doc: default 1, max 10
+        filter: Pinecone metadata filter. Fields: title, authors, date_published (int|ISO str), url, source, needs_tech, quality_score (0-10). Operators: $eq $ne $gt $gte $lt $lte $in $nin $and $or (date constraint is added automatically).
+    """
+    cutoff = datetime.now() - timedelta(days=days)
+    date_filter = {"date_published": {"$gte": int(cutoff.timestamp())}}
+
+    if filter: filter = {"$and": [date_filter, filter]}
+    else: filter = date_filter
+
+    return _search(query, k, filter, format, snippets_per_doc)
+
+
+@mcp.tool
+def lw_af_arxivsafety_get_doc(
+    id: str | None = None, url: str | None = None, title: str | None = None,
+    max_chars: int = MAX_DOC_CHARS, offset: int = 0,
+) -> str:
+    """Retrieve full text of a single article from the alignment research corpus. Use after finding an interesting result via search to read the complete document. Accepts hash_id, URL, or exact title. Non-semantic content (base64, SVGs, Plotly data) is stripped; long articles are truncated (default 130k chars). Use offset to paginate through longer articles.
+
+    Args:
+        id: Article hash_id (shown as hash_id in formatted results, or 'id' in json results). Preferred lookup method.
+        url: Article URL. Partial match.
+        title: Exact article title.
+        max_chars: Max characters to return (default 130000). The cleaned text length is reported in the response so you can decide whether to request more.
+        offset: Character offset into cleaned text (default 0). Use to retrieve subsequent pages of a long article.
+    """
+    if not any([id, url, title]):
+        return "Error: provide at least one of: id, url, title"
+
+    row = _get_article(id=id, url=url, title=title)
+    if not row:
+        return f"Article not found (searched: id={id} url={url} title={title})"
+
+    authors = row["authors"] or ""
+    date = row["date_published"].strftime("%Y-%m-%d") if row["date_published"] else "unknown"
+
+    body = clean_text(row["text"] or "")
+    total = len(body)
+    chunk = body[offset:offset + max_chars]
+
+    parts = [
+        f'<article hash_id="{row["hash_id"]}" source="{row["source"]}" cleaned_length="{total}">',
+        f'<title>{row["title"]}</title>',
+        f'<authors>{authors}</authors>',
+        f'<date>{date}</date>',
+        f'<url>{row["url"]}</url>',
+        f'<text offset="{offset}" length="{len(chunk)}">',
+        chunk,
+        f'</text>',
+    ]
+    if offset + max_chars < total:
+        parts.append(f'<remaining chars="{total - offset - len(chunk)}" next_offset="{offset + len(chunk)}" />')
+    parts.append('</article>')
+    return "\n".join(parts)
+
+
+@mcp.tool
+def lw_af_posts_sorted() -> str:
+    """Browse and list AI safety articles: by author, by recency, by source, by quality. Coming soon -- use lw_af_arxivsafety_search with filters for now."""
+    return "Not yet implemented. Use lw_af_arxivsafety_search with filter parameter instead. Example: filter={\"authors\": {\"$in\": [\"John Wentworth\"]}} or filter={\"source\": \"lesswrong\", \"date_published\": {\"$gte\": \"2024-01-01\"}}"
+
+
+# ---------------------------------------------------------------------------
+# Filter helpers
+# ---------------------------------------------------------------------------
 
 def _parse_date_to_timestamp(value: str | int) -> int:
     """Convert ISO date/datetime string to Unix timestamp, or pass through int."""
     if isinstance(value, int): return value
     if isinstance(value, str):
-        # Try ISO datetime with timezone
         for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d"):
             try:
                 dt = datetime.strptime(value, fmt)
                 return int(dt.timestamp())
             except ValueError:
                 continue
-        # Also try fromisoformat which handles more variants
         try: return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp())
         except ValueError: pass
         raise ValueError(f"Cannot parse date: {value!r}")
-    return value  # Pass through other types unchanged
+    return value
 
 
 def _convert_date_fields(filter: dict) -> dict:
@@ -107,7 +204,6 @@ def _convert_date_fields(filter: dict) -> dict:
     result = {}
     for key, value in filter.items():
         if key == "date_published":
-            # value is either a direct value or a dict of operators
             if isinstance(value, dict):
                 result[key] = {op: _parse_date_to_timestamp(v) for op, v in value.items()}
             else:
@@ -137,6 +233,5 @@ def _remap_quality_fields(filter: dict) -> dict:
 
 
 if __name__ == "__main__":
-    logger.info(f"Starting Stampy Chat MCP server on port 3002")
-    # Run as HTTP server for remote access via Caddy reverse proxy
+    logger.info("Starting Stampy Chat MCP server on port 3002")
     mcp.run(transport="http", host="127.0.0.1", port=3002)

--- a/api/src/stampy_chat/prompts.py
+++ b/api/src/stampy_chat/prompts.py
@@ -43,7 +43,7 @@ def truncate_history(history: list[Message], max_tokens: int) -> list[Message]:
 
 
 def format_block(block: Block) -> str:
-    return f'<result-fragment id={block.get("reference")} title="{block.get("title")}" authors="{", ".join(block["authors"])}" timestamp="{block["date_published"]}">\n...\n{block["text"]}\n...\n</result-fragment>'
+    return f'<result-fragment id={block.get("reference")} hash_id="{block.get("id")}" title="{block.get("title")}" authors="{", ".join(block["authors"])}" date="{block["date_published"]}">\n...\n{block["text"]}\n...\n</result-fragment>'
 
 
 def format_blocks(blocks: list[Block]) -> str:


### PR DESCRIPTION
**[Not yet reviewed by lauren]**

## Summary
- Add `lw_af_arxivsafety_get_doc` tool: retrieves full article text by hash_id, URL, or title. Cleans non-semantic content (base64, SVGs, Plotly data) via ARD regexes, truncates at 130k chars (99th percentile), returns XML.
- Add `lw_af_arxivsafety_recent` tool: date-filtered search (default last 90 days).
- Add `lw_af_posts_sorted` stub tool.
- Expose `hash_id` in formatted search results so get_doc is usable from them.
- SQL queries use SQLAlchemy Core expression builder with proper LIKE wildcard escaping.
- New standalone `align_data/embeddings/clean.py` in ARD repo (zero align_data deps, imported via importlib.util).

## Test plan
- [x] Verify search returns hash_id in formatted results
- [x] Verify get_doc retrieves article by hash_id from search
- [x] Verify get_doc by URL partial match
- [x] Verify get_doc cleans/truncates long articles
- [x] Verify LIKE escaping with URLs containing % or _
- [x] Run `cd api && pipenv run pytest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)