### PR TITLE
Deploy: restart MCP service on deploy

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -20,4 +20,5 @@ jobs:
             ./update.sh
             service website restart
             service backend restart
+            service mcp restart
             popd


### PR DESCRIPTION
One-line change: adds `service mcp restart` to the deploy action alongside website and backend restarts. The MCP service has been running since Dec 2025 without restarts on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)