### PR TITLE
Remove retired Anthropic model ids from selectable models

### DIFF
--- a/api/src/stampy_chat/settings.py
+++ b/api/src/stampy_chat/settings.py
@@ -89,10 +89,6 @@ MODELS = {
     # Dated aliases (still work)
     "anthropic/claude-sonnet-4-5-20250929":         Model(200_000, 20, 8192,  True,  1024),
     "anthropic/claude-opus-4-5-20251101":           Model(200_000, 20, 16000, True,  1024),
-    "anthropic/claude-sonnet-4-20250514":           Model(200_000, 20, 4096,  True,  1024),
-    "anthropic/claude-opus-4-20250514":             Model(200_000, 20, 4096,  True,  1024),
-    "anthropic/claude-3-7-sonnet-latest":           Model(200_000, 20, 4096,  True,  1024),
-    "anthropic/claude-3-5-sonnet-latest":           Model(200_000, 20, 4096,  False, 0),
 }
 
 DEFAULT_MIRI_FILTERS = {

--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -57,10 +57,6 @@ export const MODELS: { [key: string]: Model } = {
   "anthropic/claude-haiku-4-5": { maxNumTokens: 200_000, topKBlocks: 20 },
   "anthropic/claude-sonnet-4-5-20250929": { maxNumTokens: 200_000, topKBlocks: 20 },
   "anthropic/claude-opus-4-5-20251101": { maxNumTokens: 200_000, topKBlocks: 20 },
-  "anthropic/claude-sonnet-4-20250514": { maxNumTokens: 200_000, topKBlocks: 20 },
-  "anthropic/claude-opus-4-20250514": { maxNumTokens: 200_000, topKBlocks: 20 },
-  "anthropic/claude-3-7-sonnet-latest": { maxNumTokens: 200_000, topKBlocks: 20 },
-  "anthropic/claude-3-5-sonnet-latest": { maxNumTokens: 200_000, topKBlocks: 20 },
 };
 export const ENCODERS = ["cl100k_base"];
 export const DEFAULT_FILTERS: SearchFilters = {


### PR DESCRIPTION
## What

Removes four Anthropic model ids that now return **404 from the API** from the selectable-model allowlists in both the backend (`api/src/stampy_chat/settings.py`) and the web frontend picker (`web/src/hooks/useSettings.ts`):

- `anthropic/claude-sonnet-4-20250514`
- `anthropic/claude-opus-4-20250514`
- `anthropic/claude-3-7-sonnet-latest`
- `anthropic/claude-3-5-sonnet-latest`

Remaining valid models: `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5`, `claude-sonnet-4-5-20250929`, `claude-opus-4-5-20251101`.

## Why

Prod chat was down: every request with no explicit model fell back to `COMPLETIONS_MODEL=anthropic/claude-sonnet-4-20250514` (set in prod `api/.env`), and Anthropic has retired that id, so the backend 404'd on every chat. Already hotfixed live by pointing `COMPLETIONS_MODEL` at `claude-sonnet-4-6` and restarting the backend, so prod is restored. This PR is the durable cleanup: the retired ids were still offered as selectable options, so anyone who picked one (or passed `?model=<retired>`) would keep hitting the 404.

## Verified

Each id checked against `GET /v1/models/{id}` with the prod key: the four above return 404, the five kept return 200. `web` typechecks clean (`tsc` exit 0); backend imports fine and the env default (`claude-sonnet-4-6`) is in the trimmed allowlist.

## Note (out of scope)

The `stampy-ui` frontend has the same retired ids in a compile-time `Model` type union, but it doesn't send a model by default (relies on the backend default), so those are inert. Minor cleanup for a separate PR to that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
